### PR TITLE
Issues/1 single task per node

### DIFF
--- a/src/ticrypt.c
+++ b/src/ticrypt.c
@@ -452,9 +452,6 @@ int slurm_spank_init(spank_t sp, int ac, char **av) {
 int slurm_spank_job_prolog(spank_t sp, int ac, char **av) {
   tlog("starting job_prolog",DEBUG);
 
-  /* Define logging variables */
-  char message[BUFLEN] = "";
-
   /* Define counts to check against */
   uint32_t n_tasks = 2;
   uint32_t n_nodes = 1;

--- a/src/ticrypt.c
+++ b/src/ticrypt.c
@@ -446,6 +446,43 @@ int slurm_spank_init(spank_t sp, int ac, char **av) {
 
 /* ************************************************************************** */
 /*                                                                            */
+/*                             job_prolog                                     */
+/*                                                                            */
+/* ************************************************************************** */
+int slurm_spank_job_prolog(spank_t sp, int ac, char **av) {
+  tlog("starting job_prolog",DEBUG);
+
+  /* Define logging variables */
+  char message[BUFLEN] = "";
+
+  /* Define counts to check against */
+  uint32_t n_tasks = 2;
+  uint32_t n_nodes = 1;
+
+  /* Get task and node counts from environment */
+  if ( spank_get_item(sp,S_JOB_NNODES,&n_nodes) != ESPANK_SUCCESS ) {
+    tlog("could not determine number of nodes in job",ERROR);
+    return FAIL;
+  }
+
+  if ( spank_get_item(sp,S_JOB_TOTAL_TASK_COUNT,&n_nodes) != ESPANK_SUCCESS ) {
+    tlog("could not determine number of tasks in job",ERROR);
+    return FAIL;
+  }
+
+  /* Verify total task count does not exceed node count */
+  /* https://github.com/UFResearchComputing/ticrypt-spank/issues/1 */
+  if ( n_tasks > n_nodes ) {
+    tlog("ticrypt jobs require a single task per node",ERROR);
+    return FAIL;
+  } 
+
+
+  return PASS;
+}
+
+/* ************************************************************************** */
+/*                                                                            */
 /*                         task_init_privileged                               */
 /*                                                                            */
 /* ************************************************************************** */

--- a/src/ticrypt.c
+++ b/src/ticrypt.c
@@ -433,47 +433,87 @@ struct spank_option spank_options[] = {
   SPANK_OPTIONS_TABLE_END
 };
 
+
 /* ************************************************************************** */
 /*                                                                            */
-/*                        OPTIONS REGISTRATION                                */
+/*                                init                                        */
 /*                                                                            */
 /* ************************************************************************** */
 int slurm_spank_init(spank_t sp, int ac, char **av) {
+  tlog("starting init",DEBUG);
+
+  /* Register spank options */
   spank_option_register(sp,spank_options);
-  return 0;
+
+  return PASS;
 }
 
-
 /* ************************************************************************** */
 /*                                                                            */
-/*                             job_prolog                                     */
+/*                             user_init                                      */
 /*                                                                            */
 /* ************************************************************************** */
-int slurm_spank_job_prolog(spank_t sp, int ac, char **av) {
-  tlog("starting job_prolog",DEBUG);
+int slurm_spank_user_init(spank_t sp, int ac, char **av) {
+  tlog("starting user_init",DEBUG);
+  /* Define logging variables */
+  char message[BUFLEN] = "";
 
-  /* Define counts to check against */
+  /* Register spank options */
+  spank_option_register(sp,spank_options);
+
+  /* Verify total task count does not exceed node count */
+  /* https://github.com/UFResearchComputing/ticrypt-spank/issues/1 */
   uint32_t n_tasks = 2;
   uint32_t n_nodes = 1;
-
-  /* Get task and node counts from environment */
   if ( spank_get_item(sp,S_JOB_NNODES,&n_nodes) != ESPANK_SUCCESS ) {
     tlog("could not determine number of nodes in job",ERROR);
     return FAIL;
   }
-
-  if ( spank_get_item(sp,S_JOB_TOTAL_TASK_COUNT,&n_nodes) != ESPANK_SUCCESS ) {
+  if ( spank_get_item(sp,S_JOB_TOTAL_TASK_COUNT,&n_tasks) != ESPANK_SUCCESS ) {
     tlog("could not determine number of tasks in job",ERROR);
     return FAIL;
   }
-
-  /* Verify total task count does not exceed node count */
-  /* https://github.com/UFResearchComputing/ticrypt-spank/issues/1 */
+  sprintf(message,"job request with %d tasks on %d nodes",n_tasks,n_nodes);
+  tlog(message,DEBUG);
   if ( n_tasks > n_nodes ) {
     tlog("ticrypt jobs require a single task per node",ERROR);
     return FAIL;
   } 
 
+  return PASS;
+}
+
+/* ************************************************************************** */
+/*                                                                            */
+/*                          local_user_init                                   */
+/*                                                                            */
+/* ************************************************************************** */
+int slurm_spank_local_user_init(spank_t sp, int ac, char **av) {
+  tlog("starting local_user_init",DEBUG);
+  /* Define logging variables */
+  char message[BUFLEN] = "";
+
+  /* Register spank options */
+  spank_option_register(sp,spank_options);
+
+  /* Verify total task count does not exceed node count */
+  /* https://github.com/UFResearchComputing/ticrypt-spank/issues/1 */
+  uint32_t n_tasks = 2;
+  uint32_t n_nodes = 1;
+  if ( spank_get_item(sp,S_JOB_NNODES,&n_nodes) != ESPANK_SUCCESS ) {
+    tlog("could not determine number of nodes in job",ERROR);
+    return FAIL;
+  }
+  if ( spank_get_item(sp,S_JOB_TOTAL_TASK_COUNT,&n_tasks) != ESPANK_SUCCESS ) {
+    tlog("could not determine number of tasks in job",ERROR);
+    return FAIL;
+  }
+  sprintf(message,"job request with %d tasks on %d nodes",n_tasks,n_nodes);
+  tlog(message,DEBUG);
+  if ( n_tasks > n_nodes ) {
+    tlog("ticrypt jobs require a single task per node",ERROR);
+    return FAIL;
+  } 
 
   return PASS;
 }


### PR DESCRIPTION
check ntasks versus number of allocated nodes to avoid duplicated node re-configuration processes. 