### PR TITLE
* fix duplicated options registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,9 @@ slurm: $(slurm)
 install: $(library) $(doc) $(submit)
 	mkdir -p $(LIB)
 	install -m 0755 $(library) $(LIB)/$(library)
-	install -m 0640 config/ticrypt-spank.conf /etc/ticrypt-spank.conf
+	#install -m 0640 config/ticrypt-spank.conf /etc/ticrypt-spank.conf
 	install -m 0644 $(doc) /usr/local/share/man/man8/ticrypt-spank.8.gz
-	install -m 0755 $(plugin) $(LIB)/$(plugin)
+	install -m 0755 $(submit) $(LIB)/$(submit)
 
 clean:
 	rm -f $(library)

--- a/src/spank/ticrypt.c
+++ b/src/spank/ticrypt.c
@@ -471,17 +471,6 @@ int ticrypt_settings_init(ticrypt_settings_t *settings,int job_id) {
 static int ticrypt = FALSE;
 static int _ticrypt_opt_flag_process( int val, const char *optarg, int remote );
 
-struct spank_option spank_options[] = {
-  { 
-    "ticrypt",
-    "",
-	"Trigger ticrypt node reconfiguration",
-    2,
-    0,
-	(spank_opt_cb_f) _ticrypt_opt_flag_process
-  },
-  SPANK_OPTIONS_TABLE_END
-};
 
 
 /* ************************************************************************** */
@@ -493,6 +482,17 @@ int slurm_spank_init(spank_t sp, int ac, char **av) {
   tlog("starting init",DEBUG);
 
   /* Register spank options */
+  struct spank_option spank_options[] = {
+    { 
+      "ticrypt",
+      "",
+  	"Trigger ticrypt node reconfiguration",
+      2,
+      0,
+  	(spank_opt_cb_f) _ticrypt_opt_flag_process
+    },
+    SPANK_OPTIONS_TABLE_END
+  };
   spank_option_register(sp,spank_options);
 
   tlog("completed init",DEBUG);

--- a/ticrypt-spank.spec
+++ b/ticrypt-spank.spec
@@ -1,6 +1,6 @@
 Name:       ticrypt-spank	
 Version:    1.2
-Release:    3
+Release:    4
 Summary:    Ticrypt spank plugin for Slurm
 
 License:    GPLv3	
@@ -48,6 +48,8 @@ rm -rf %{buildroot}
 %doc
 
 %changelog
+* Thu Jan 2 2020 William Howell <whowell@rc.ufl.edu> - 1.2-4
+- Fix duplicated spank plugin option registration
 * Wed Nov 27 2019 William Howell <whowell@rc.ufl.edu> - 1.2-3
 - Fix up build docs
 * Wed Nov 27 2019 William Howell <whowell@rc.ufl.edu> - 1.2


### PR DESCRIPTION
The plugin's options declaration needed to be moved into the spank init tie in instead of being globally. This was checked via sbatch and srun. Additionally the makefile had a leftover typo so to speak resulting in 'make install' not actually installing the plugin. 